### PR TITLE
Remove overwritten grey property

### DIFF
--- a/client/src/styles.js
+++ b/client/src/styles.js
@@ -17,7 +17,6 @@ export const colors = {
   secondary: SKColors.teal.base,
   accent: SKColors.pink.base,
   background: SKColors.silver.light,
-  grey: SKColors.silver.dark,
   text: SKColors.black.base,
   textSecondary: SKColors.grey.dark,
   ...SKColors,


### PR DESCRIPTION
The `colors.grey` property will be overwritten by `SKColors.grey` and hasn't therefone any effect.