### PR TITLE
fix-node-openssl

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -19,7 +19,7 @@
     "react-scripts": "^4.0.3"
   },
   "scripts": {
-    "start": "react-scripts start",
+    "start": "react-scripts --openssl-legacy-provider start",
     "build": "react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject"

--- a/final/client/package.json
+++ b/final/client/package.json
@@ -21,7 +21,7 @@
     "react-scripts": "^4.0.3"
   },
   "scripts": {
-    "start": "react-scripts start",
+    "start": "react-scripts --openssl-legacy-provider start",
     "build": "react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject"
@@ -50,3 +50,4 @@
   "author": "Raphael Terrier @R4ph-t",
   "license": "MIT"
 }
+


### PR DESCRIPTION
fix: this change avoids making the students having to install node version 16 to run the client due to a dependency issue with openssl and node 17+
(https://github.com/webpack/webpack/issues/14532#issuecomment-947012063)