### PR TITLE
Added "@apollo/server" to dependencies

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -8,6 +8,7 @@
   },
   "dependencies": {},
   "devDependencies": {
+    "@apollo/server": "^4.0.0",
     "dotenv": "^16.0.0",
     "nodemon": "^2.0.20"
   },


### PR DESCRIPTION
In the tutorial we never do `npm install apollo` so we need by default.