### PR TITLE
refactor: fix some of styles object properties having initial type as array instead of string

### DIFF
--- a/client/src/styles.js
+++ b/client/src/styles.js
@@ -25,7 +25,7 @@ export const colors = {
 const GlobalStyles = () => (
   <Global
     styles={{
-      [['html', 'body']]: {
+      'html, body': {
         height: '100%',
       },
       body: {
@@ -44,7 +44,7 @@ const GlobalStyles = () => (
       '*': {
         boxSizing: 'border-box',
       },
-      [['h1', 'h2', 'h3', 'h4', 'h5', 'h6']]: {
+      'h1, h2, h3, h4, h5, h6': {
         margin: 0,
         fontWeight: 600,
       },


### PR DESCRIPTION
In `styles.js` file, some of the properties in the styles object are written as arrays instead of strings. 
I thought this was some syntax specific to **emotion** or **styled-components**, but it seemed as if this is just a syntactic sugar instead of writing it as a normal string. 

Examples explain more: 
```js
 [['h1', 'h2', 'h3', 'h4', 'h5', 'h6']]: {
        margin: 0,
        fontWeight: 600,
      },
// vs
'h1, h2, h3, h4, h5, h6': {
        margin: 0,
        fontWeight: 600,
      },
```

The array will be coerced to a string, so the end result of both of them will be the same . 
But I think that using a string, which includes valid css selectors, is more natural on using an array then depending on js coercing it to a string. 

If this is a normal way of writing object properties when using libraries like **styled-components**, I would be grateful if you mention some resources so I can learn more about that. 